### PR TITLE
Экранирование JS для текстовых значений атрибутов

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
-	* auto escape attributes expressions
+	* escape attributes text values in compiler
+	* auto escape attributes expressions for HTML entities
 	* added __fest_self = this for blocks
 	* add bench test
 	* add value attribute in "for" and "each"

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -34,6 +34,34 @@ var compile = (function(){
                       embed: true, hr: true, img: true, input: true, keygen: true,
                       link: true, meta: true, param: true, source: true, wbr: true };
 
+    var jschars=/[\\'"\/\n\t\b\f<>]/g;
+
+    var jshash = {
+        "\"":"\\\"",
+        "\\":"\\\\",
+        "/" :"\\/",
+        "\n":"\\n",
+        "\t":"\\t",
+        "\b":"\\b",
+        "\f":"\\f",
+        "'" :"\\'",
+        "<" :"\\u003C",
+        ">" :"\\u003E"
+    };
+
+    var htmlhash = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": '&gt;',
+        '"': '&quot;'
+    };
+
+    function escapeJS(s){
+        return s.replace(jschars, function (chr){
+            return jshash[chr];
+        });
+    }
+
     function getName(name){
         if (/^[a-zA-Z_]+$/.test(name)){
             return '.' + name;
@@ -53,15 +81,18 @@ var compile = (function(){
         for (i in attrs){
             attrValue = attrs[i].value.replace(/{{/g, "__DOUBLE_LEFT_CURLY_BRACES__").replace(/}}/g, "__DOUBLE_RIGHT_CURLY_BRACES__");
 
-            if (/{[^}]*}/.test(attrValue)){
-                attrValue = attrValue.replace(/{[^}]*}/g, function(expr) {
-                    result.expr[n] = expr.replace(/^{/, '').replace(/}$/, '').replace(/__DOUBLE_LEFT_CURLY_BRACES__/g, "{").replace(/__DOUBLE_RIGHT_CURLY_BRACES__/g, "}");
-                    return '"+__fest_attrs[' + n++ + ']+"';
-                });
-            }
-
-            attrValue = attrValue.replace(/__DOUBLE_LEFT_CURLY_BRACES__/g, "{").replace(/__DOUBLE_RIGHT_CURLY_BRACES__/g, "}");
-            result.text += ' ' + i + '=\\"' + attrValue.replace(/\r|\n/g, "\\n") + '\\"';
+            result.text += ' ' + i + '=\\"'
+            attrValue.match(/{[^}]*}|[^{}]*/g).forEach(function (str) {
+                if (str !== '') {
+                    if (str[0] === '{') {
+                        result.expr[n] = str.slice(1, -1).replace(/__DOUBLE_LEFT_CURLY_BRACES__/g, "{").replace(/__DOUBLE_RIGHT_CURLY_BRACES__/g, "}");
+                        result.text += '" + __fest_attrs[' + n++ + '] + "';
+                    } else {
+                        result.text += escapeJS(str).replace(/__DOUBLE_LEFT_CURLY_BRACES__/g, "{").replace(/__DOUBLE_RIGHT_CURLY_BRACES__/g, "}");
+                    }
+                }
+            });
+            result.text += '\\"';
         }
         return result;
     }
@@ -458,34 +489,14 @@ var compile = (function(){
         options.sax.strict = options.sax.strict || true;
 
         function build_template(result) {
-            var __fest_jshash = {
-                "\"":"\\\"",
-                "\\":"\\\\",
-                "/" :"\\/",
-                "\n":"\\n",
-                "\t":"\\t",
-                "\b":"\\b",
-                "\f":"\\f",
-                "'" :"\\'",
-                "<" :"\\u003C",
-                ">" :"\\u003E"
-            };
-
-            var __fest_htmlhash = {
-              "&": "&amp;",
-              "<": "&lt;",
-              ">": '&gt;',
-              '"': '&quot;'
-            };
-
             template  = 'function ' + name + '(__fest_context){"use strict";' +
                         'var __fest_self=this,__fest_str="",__fest_result=[],__fest_contexts=[],__fest_attrs=[],__fest_if,__fest_foreach,__fest_from,__fest_to,__fest_html = "",' +
                         '__fest_blocks={},__fest_params,__fest_log_error,___fest_log_error,__fest_pushstr,' +
                         '__fest_debug_file="",__fest_debug_line="",__fest_debug_block="",' +
                         '__fest_htmlchars=/[&<>\\"]/g,' +
-                        '__fest_htmlhash=' + JSON.stringify(__fest_htmlhash) + ',' +
-                        '__fest_jschars=/[\\\'\\"\\/\\n\\t\\b\\f<>]/g,' +
-                        '__fest_jshash=' + JSON.stringify(__fest_jshash) + ';' +
+                        '__fest_htmlhash=' + JSON.stringify(htmlhash) + ',' +
+                        '__fest_jschars=/' + jschars.source + '/g,' +
+                        '__fest_jshash=' + JSON.stringify(jshash) + ';' +
                         'if(typeof __fest_push === "undefined"){__fest_pushstr=function(ctx, str){__fest_str+=str}}else{__fest_pushstr=__fest_push}' +
                         'if(typeof __fest_error === "undefined"){___fest_log_error = function(){return console.error.apply(console,arguments);};}else{___fest_log_error=__fest_error}' +
                         'function __fest_replaceHTML(chr){return __fest_htmlhash[chr];}' +

--- a/tests/templates/attribute_expression.xml
+++ b/tests/templates/attribute_expression.xml
@@ -20,17 +20,17 @@
         data-quot="{'\&quot;'}"
         data-elcb="{'{{'}"
         data-ercb="{'}}'}"
-        data-lcb="{"
-        data-rcb="}"
+        data-lcb="{{"
+        data-rcb="}}"
         data-ecb="{'{{}}'}"
         data-dcb="{{}}"
         data-crazy="{'{{{{}}{{}}}}'}"
         data-crazy-again="{{{{}}{{}}}}"
-        data-crazy-too="{{}{}}"
+        data-crazy-too="{{}}{{}}"
     >
         <div class="{block}{modifier}" data-has-modifier="{!!(block && modifier)}"/>
-        <div class="{block + element}" data-obj-value="{ {{ 'key': 'value' }}['key'] }" data-obj-json="{{ \&quot;key\&quot;: \&quot;value\&quot; }}">
-            <span class="{'name'}" data-spec-chars="{{&lt;\&quot;\&apos;&amp;&gt;}}" data-espec-chars="{'{{&lt;\&quot;\&apos;&amp;&gt;}}'}">
+        <div class="{block + element}" data-obj-value="{ {{ 'key': 'value' }}['key'] }" data-obj-json="{{ &quot;key&quot;: &quot;value&quot; }}">
+            <span class="{'name'}" data-spec-chars="{{&lt;&quot;&apos;&amp;&gt;}}" data-espec-chars="{'{{&lt;&quot;\&apos;&amp;&gt;}}'}">
                 <fest:get name="modify">{ "block": block, "element": element }</fest:get>
             </span>
         </div>
@@ -39,7 +39,9 @@
         <fest:value>value</fest:value>
     </fest:for>
 
-	<div class="a
-b">
-	</div>
+    <fest:script>
+        var a = 'A';
+        var b = 'B';
+    </fest:script>
+	<div data-lf="a&#x0A;b" data-backslash="\" data-apos="&apos;" data-quot="&quot;" data-block="{a}{" data-block-with-text="}a{b}{{c}}"></div>
 </fest:template>

--- a/tests/tests-fest.js
+++ b/tests/tests-fest.js
@@ -254,7 +254,7 @@ vows.describe('Fast tests').addBatch({
             return promise;
         },
         'result':function(result){
-            assert.equal(result, '<div class="b-block" data-amp="&amp;" data-lt="&lt;" data-gt="&gt;" data-apos="\'" data-quot="&quot;" data-elcb="{" data-ercb="}" data-lcb="{" data-rcb="}" data-ecb="{}" data-dcb="{}" data-crazy="{{}{}}" data-crazy-again="{{}{}}" data-crazy-too="{}{}"><div class="b-block_modifier" data-has-modifier="true"></div><div class="b-block__element" data-obj-value="value" data-obj-json="{ "key": "value" }"><span class="name" data-spec-chars="{<"\'&>}" data-espec-chars="{&lt;&quot;\'&amp;&gt;}">b-block__element_modifier</span></div></div>1245<div class="a\nb"></div>');
+            assert.equal(result, '<div class="b-block" data-amp="&amp;" data-lt="&lt;" data-gt="&gt;" data-apos="\'" data-quot="&quot;" data-elcb="{" data-ercb="}" data-lcb="{" data-rcb="}" data-ecb="{}" data-dcb="{}" data-crazy="{{}{}}" data-crazy-again="{{}{}}" data-crazy-too="{}{}"><div class="b-block_modifier" data-has-modifier="true"></div><div class="b-block__element" data-obj-value="value" data-obj-json="{ "key": "value" }"><span class="name" data-spec-chars="{<"\'&>}" data-espec-chars="{&lt;&quot;\'&amp;&gt;}">b-block__element_modifier</span></div></div>1245<div data-lf="a\nb" data-backslash="\\" data-apos="\'" data-quot=""" data-block="A" data-block-with-text="aB{c}"></div>');
         }
     },
     'document.write': {


### PR DESCRIPTION
Для примера ниже компилятор создавал невалидный JS код, так как JS символы не экранировались в текстовых данных атрибутов:

``` xml
<div data-lf="&#x0A" data-backslash="\" data-quot="&quot;"></div>
```

Переделал compileAttributes() и подправил тесты.

Немного отрефакторил build_template(), чтобы регулярка для экранирования JS была одна и таже (для компилятора и шаблонов)
