### PR TITLE
added set/get optimizations

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+        * set/get optimizations
 	* rename name in fest:element to select
 	* add select in fest:get
 	* fest:element added

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -73,12 +73,6 @@ var compile = (function(){
         }
     }
 
-    function resolve(promise, promises, fn){
-        if (promises === 0){
-            promise.resolve(fn.join('').replace(/";__fest_str\+="/g, ''));
-        }
-    }
-
     function compileAttributes(attrs){
         var i, result = { 'text': '', 'expr': [], 'name': [] }, n = 0, attrValue = '';
         for (i in attrs){
@@ -101,7 +95,7 @@ var compile = (function(){
         return result;
     }
 
-    function callback(type, data, fn, callbacks){
+    function callback(type, data, section, callbacks){
         if (typeof callbacks[type] !== 'function'){
             return false;
         }
@@ -110,12 +104,12 @@ var compile = (function(){
             return false;
         }
         if (typeof result === 'string'){
-            fn[fn.length - 1] += result;
+            section.source += result;
         }
         return true;
     }
 
-    function closetag(stack, name, fn, opentag, context_name){
+    function closetag(stack, name, section, opentag, context_name){
         if (!opentag){
             return false;
         }
@@ -123,13 +117,13 @@ var compile = (function(){
             return opentag;
         }
         if (stack[stack.length - 1] === 'shorttag'){
-            fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"/>");';
+            section.source += '__fest_pushstr(' + context_name + ',"/>");';
         } else if (stack[stack.length - 1] === 'element') {
-            fn[fn.length - 1] += '__fest_elementName = __fest_element_stack[__fest_element_stack.length - 1];';
-            fn[fn.length - 1] += 'if(__fest_elementName in __fest_short_tags){__fest_pushstr(' + context_name + ',"/")}';
-            fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',">");';
+            section.source += '__fest_elementName = __fest_element_stack[__fest_element_stack.length - 1];';
+            section.source += 'if(__fest_elementName in __fest_short_tags){__fest_pushstr(' + context_name + ',"/")}';
+            section.source += '__fest_pushstr(' + context_name + ',">");';
         } else {
-            fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',">");';
+            section.source += '__fest_pushstr(' + context_name + ',">");';
         }
         return false;
     }
@@ -220,20 +214,22 @@ var compile = (function(){
         };
     }
 
-    function push_debug_info(fn, parser, compile_file, block, debug){
+    function push_debug_info(section, parser, compile_file, block, debug){
         if (!debug){
             return;
         }
-        fn[fn.length - 1] += '__fest_debug_file="' + compile_file + '";';
-        fn[fn.length - 1] += '__fest_debug_line="' + parser.line + '";';
-        fn[fn.length - 1] += '__fest_debug_block="' + block + '";';
+        section.source += '__fest_debug_file="' + compile_file + '";';
+        section.source += '__fest_debug_line="' + parser.line + '";';
+        section.source += '__fest_debug_block="' + block + '";';
     }
 
-    function _compile (file, context_name, callbacks, options, cb){
+    function _compile (file, context_name, callbacks, options, output){
+        output = output || {sections: [], uses: []};
+
         var counters = {counter: 0, promises: 1},
             choose = [],
-            fn = [''],
             stack = [],
+            section = flush(),
             opentag = false,
             templateClosed = false,
             parser = sax.parser(options.sax.strict, options.sax),
@@ -243,13 +239,22 @@ var compile = (function(){
             _getEval = getEval(compile_file, parser),
             attrs;
 
+        function flush(parent, name) {
+            var section = {
+                source: '',
+                name: name,
+                parent: parent
+            };
+            output.sections.push(section);
+            return section;
+        }
+
         parser.onopentag = function (node) {
-            if (callback('opentag', node, fn, callbacks)) return;
+            if (callback('opentag', node, section, callbacks)) return;
 
-            push_debug_info(fn, parser, file, node.name, options.debug);
+            push_debug_info(section, parser, file, node.name, options.debug);
 
-
-            opentag = closetag(stack, node.local, fn, opentag, context_name);
+            opentag = closetag(stack, node.local, section, opentag, context_name);
 
             if (!opentag && node.local == 'attributes') {
                 throw new Error(file + "\n" + errorMessage('fest:attributes must be the first child', parser.line, compile_file));
@@ -262,11 +267,11 @@ var compile = (function(){
             if (node.ns[node.prefix] != fest_ns){
                 attrs = compileAttributes(node.attributes);
                 for (var i = 0; i < attrs.expr.length; i++) {
-                    fn[fn.length - 1] += 'try{__fest_attrs[' + i + ']=__fest_escapeHTML(' + _getExpr(attrs.expr[i], 'expression #' + (i + 1) + ' in attribute "' +  attrs.name[i] + '"') + ')}catch(e){__fest_attrs[' + i + ']=""; __fest_log_error(e.message);}';
+                    section.source += 'try{__fest_attrs[' + i + ']=__fest_escapeHTML(' + _getExpr(attrs.expr[i], 'expression #' + (i + 1) + ' in attribute "' +  attrs.name[i] + '"') + ')}catch(e){__fest_attrs[' + i + ']=""; __fest_log_error(e.message);}';
                 }
                 stack.push(node.name in short_tags ? 'shorttag' : 'tag');
                 opentag = true;
-                fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"<' + node.name + attrs.text + '");';
+                section.source += '__fest_pushstr(' + context_name + ',"<' + node.name + attrs.text + '");';
                 return;
             }
             stack.push(node.local);
@@ -274,145 +279,144 @@ var compile = (function(){
             switch (node.local){
                 case 'element':
                     opentag = true;
-                    fn[fn.length - 1] += '__fest_elementName="";';
-                    fn[fn.length - 1] += 'try{__fest_elementName=' + _getAttr(node, 'select', 'expr') + ';';
-                    fn[fn.length - 1] += 'if(typeof __fest_elementName !== "string"){__fest_log_error("Element name must be a string");__fest_elementName="div"}';
-                    fn[fn.length - 1] += '}catch(e){__fest_elementName="div";__fest_log_error(e.message);}';
-                    fn[fn.length - 1] += '__fest_element_stack.push(__fest_elementName);';
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"<" + __fest_elementName);';
+                    section.source += '__fest_elementName="";';
+                    section.source += 'try{__fest_elementName=' + _getAttr(node, 'select', 'expr') + ';';
+                    section.source += 'if(typeof __fest_elementName !== "string"){__fest_log_error("Element name must be a string");__fest_elementName="div"}';
+                    section.source += '}catch(e){__fest_elementName="div";__fest_log_error(e.message);}';
+                    section.source += '__fest_element_stack.push(__fest_elementName);';
+                    section.source += '__fest_pushstr(' + context_name + ',"<" + __fest_elementName);';
                     return;
                 case 'template':
                     node.context_name = context_name;
                     context_name = (node.attributes.context_name ? _getAttr(node, 'context_name', 'var') : context_name);
                     if (context_name !== node.context_name){
-                        fn[fn.length - 1] += 'var ' + context_name + '=' + node.context_name + ';';
+                        section.source += 'var ' + context_name + '=' + node.context_name + ';';
                     }
                     return;
                 case 'doctype':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"<!DOCTYPE ");';
+                    section.source += '__fest_pushstr(' + context_name + ',"<!DOCTYPE ");';
                     return;
                 case 'attribute':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + '," ' + escapeJS(_getAttr(node, 'name')) + '=\\"");';
+                    section.source += '__fest_pushstr(' + context_name + '," ' + escapeJS(_getAttr(node, 'name')) + '=\\"");';
                     return;
                 case 'comment':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"<!--");';
+                    section.source += '__fest_pushstr(' + context_name + ',"<!--");';
                     return;
                 case 'cdata':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"<![CDATA[");';
+                    section.source += '__fest_pushstr(' + context_name + ',"<![CDATA[");';
                     return;
                 case 'text':
-                    fn[fn.length - 1] += node.attributes.value ? '__fest_pushstr(' + context_name + ',"' + escapeJS(_getAttr(node, 'value')) + '");' : '';
+                    section.source += node.attributes.value ? '__fest_pushstr(' + context_name + ',"' + escapeJS(_getAttr(node, 'value')) + '");' : '';
                     return;
                 case 'space':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + '," ");';
+                    section.source += '__fest_pushstr(' + context_name + '," ");';
                     return;
                 case 'if':
-                    fn[fn.length - 1] += 'try{__fest_if=' + _getAttr(node, 'test', 'expr') + '}catch(e){__fest_if=false;__fest_log_error(e.message);}';
-                    fn[fn.length - 1] += 'if(__fest_if){';
+                    section.source += 'try{__fest_if=' + _getAttr(node, 'test', 'expr') + '}catch(e){__fest_if=false;__fest_log_error(e.message);}';
+                    section.source += 'if(__fest_if){';
                     return;
                 case 'choose':
                     choose[choose.length] = 0;
                     return;
                 case 'when':
                     choose[choose.length - 1]++;
-                    fn[fn.length - 1] += 'try{__fest_if=' + _getAttr(node, 'test', 'expr') + '}catch(e){__fest_if=false; __fest_log_error(e.message);}';
-                    fn[fn.length - 1] += 'if(__fest_if){';
+                    section.source += 'try{__fest_if=' + _getAttr(node, 'test', 'expr') + '}catch(e){__fest_if=false; __fest_log_error(e.message);}';
+                    section.source += 'if(__fest_if){';
                     return;
                 case 'otherwise':
                     return;
                 case 'value':
                     node.__fest_output = node.attributes.output ? node.attributes.output.value : 'html';
                     if (!node.attributes.safe){
-                        fn[fn.length - 1] += 'try{';
+                        section.source += 'try{';
                     }
                     if (node.__fest_output === 'text'){
-                        fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',';
+                        section.source += '__fest_pushstr(' + context_name + ',';
                     } else if(node.__fest_output === 'js') {
-                        fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',__fest_escapeJS(';
+                        section.source += '__fest_pushstr(' + context_name + ',__fest_escapeJS(';
                     } else {
-                        fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',__fest_escapeHTML(';
+                        section.source += '__fest_pushstr(' + context_name + ',__fest_escapeHTML(';
                     }
                     return;
                 case 'script':
                     if (!node.attributes.safe){
-                        fn[fn.length - 1] += 'try{';
+                        section.source += 'try{';
                     }
                     if (node.attributes.src){
-                        fn[fn.length - 1] += _getEval(readFileSync(dirname(file) + '/' + node.attributes.src.value, 'utf-8'));
+                        section.source += _getEval(readFileSync(dirname(file) + '/' + node.attributes.src.value, 'utf-8'));
                     }
                     return;
                 case 'call':
-                    fn[fn.length - 1] += 'try{__fest_pushstr(' + context_name + ',' + _getAttr(node, 'name', 'expr') + '(' + _getAttr(node, 'data', 'expr') + '))}catch(e){__fest_log_error(e.message)}';
+                    section.source += 'try{__fest_pushstr(' + context_name + ',' + _getAttr(node, 'name', 'expr') + '(' + _getAttr(node, 'data', 'expr') + '))}catch(e){__fest_log_error(e.message)}';
                     return;
                 case 'insert':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"' + escapeJS(readFileSync(dirname(file) + '/' + _getAttr(node, 'src'), 'utf-8')) + '");';
+                    section.source += '__fest_pushstr(' + context_name + ',"' + escapeJS(readFileSync(dirname(file) + '/' + _getAttr(node, 'src'), 'utf-8')) + '");';
                     return;
                 case 'each':
-                    fn[fn.length - 1] += 'var ' + _getAttr(node, 'index', 'var') + (node.attributes.value ? ',' + _getAttr(node, 'value', 'var')  : '') + ';';
-                    fn[fn.length - 1] += 'try{__fest_foreach=' + _getAttr(node, 'iterate', 'expr') + ' || {};}catch(e){__fest_foreach={};__fest_log_error(e.message);}';
-                    fn[fn.length - 1] += 'for(' + _getAttr(node, 'index') + ' in __fest_foreach){';
+                    section.source += 'var ' + _getAttr(node, 'index', 'var') + (node.attributes.value ? ',' + _getAttr(node, 'value', 'var')  : '') + ';';
+                    section.source += 'try{__fest_foreach=' + _getAttr(node, 'iterate', 'expr') + ' || {};}catch(e){__fest_foreach={};__fest_log_error(e.message);}';
+                    section.source += 'for(' + _getAttr(node, 'index') + ' in __fest_foreach){';
                     if (node.attributes.value) {
-                        fn[fn.length - 1] += _getAttr(node, 'value') + '=' + _getAttr(node, 'iterate') + '[' + _getAttr(node, 'index') + '];';
+                        section.source += _getAttr(node, 'value') + '=' + _getAttr(node, 'iterate') + '[' + _getAttr(node, 'index') + '];';
                     }
                     return;
                 case 'foreach':
                     __fest_log_error('forearch deprecated use for');
                 case 'for':
-                    fn[fn.length - 1] += 'var ' + _getAttr(node, 'index', 'var') + (node.attributes.value ? ',' + _getAttr(node, 'value', 'var')  : '') + ',__fest_l' + counters.counter + ',__fest_from' + counters.counter + ',__fest_to' + counters.counter + ';';
+                    section.source += 'var ' + _getAttr(node, 'index', 'var') + (node.attributes.value ? ',' + _getAttr(node, 'value', 'var')  : '') + ',__fest_l' + counters.counter + ',__fest_from' + counters.counter + ',__fest_to' + counters.counter + ';';
                     if (node.attributes.iterate){
-                        fn[fn.length - 1] += 'try{__fest_foreach=' + _getAttr(node, 'iterate', 'expr') + ' || [];}catch(e){__fest_foreach=[];__fest_log_error(e.message);}';
-                        fn[fn.length - 1] += '__fest_l' + counters.counter + ' = (typeof __fest_foreach === "number" ? __fest_foreach : typeof __fest_foreach === "string" ? parseInt(__fest_foreach, 10) : __fest_foreach.length || 0);';
-                        fn[fn.length - 1] += 'for(' + _getAttr(node, 'index') + ' = 0;' + _getAttr(node, 'index') + '<__fest_l' + counters.counter + ';' + node.attributes.index.value + '++){';
+                        section.source += 'try{__fest_foreach=' + _getAttr(node, 'iterate', 'expr') + ' || [];}catch(e){__fest_foreach=[];__fest_log_error(e.message);}';
+                        section.source += '__fest_l' + counters.counter + ' = (typeof __fest_foreach === "number" ? __fest_foreach : typeof __fest_foreach === "string" ? parseInt(__fest_foreach, 10) : __fest_foreach.length || 0);';
+                        section.source += 'for(' + _getAttr(node, 'index') + ' = 0;' + _getAttr(node, 'index') + '<__fest_l' + counters.counter + ';' + node.attributes.index.value + '++){';
                         if (node.attributes.value) {
-                            fn[fn.length - 1] += _getAttr(node, 'value') + '=' + _getAttr(node, 'iterate') + '[' + _getAttr(node, 'index') + '];';
+                            section.source += _getAttr(node, 'value') + '=' + _getAttr(node, 'iterate') + '[' + _getAttr(node, 'index') + '];';
                         }
                     } else {
-                        fn[fn.length - 1] += 'try{__fest_from' + counters.counter + '=' + _getAttr(node, 'from', 'expr') + ';}catch(e){__fest_from' + counters.counter + '=0;__fest_log_error(e.message);}';
-                        fn[fn.length - 1] += 'try{__fest_to' + counters.counter + '=' + _getAttr(node, 'to', 'expr') + ';}catch(e){__fest_to' + counters.counter + '=0;__fest_log_error(e.message);}';
-                        fn[fn.length - 1] += 'for(' + _getAttr(node, 'index') + ' = __fest_from' + counters.counter + ';' + _getAttr(node, 'index') + '<=__fest_to' + counters.counter + ';' + _getAttr(node, 'index') + '++){';
+                        section.source += 'try{__fest_from' + counters.counter + '=' + _getAttr(node, 'from', 'expr') + ';}catch(e){__fest_from' + counters.counter + '=0;__fest_log_error(e.message);}';
+                        section.source += 'try{__fest_to' + counters.counter + '=' + _getAttr(node, 'to', 'expr') + ';}catch(e){__fest_to' + counters.counter + '=0;__fest_log_error(e.message);}';
+                        section.source += 'for(' + _getAttr(node, 'index') + ' = __fest_from' + counters.counter + ';' + _getAttr(node, 'index') + '<=__fest_to' + counters.counter + ';' + _getAttr(node, 'index') + '++){';
                     }
                     counters.counter++;
                     return;
                 case 'set':
+                    section = flush(section, _getAttr(node, 'name'));
                     if (node.attributes.test){
-                        fn[fn.length - 1] += 'try{__fest_if=' + _getAttr(node, 'test', 'expr') + '}catch(e){__fest_if=false; __fest_log_error(e.message)}';
+                        section.source += 'try{__fest_if=' + _getAttr(node, 'test', 'expr') + '}catch(e){__fest_if=false; __fest_log_error(e.message)}';
                     } else {
-                        fn[fn.length - 1] += '__fest_if=true;';
+                        section.source += '__fest_if=true;';
                     }
-                    fn[fn.length - 1] += 'if(__fest_if){';
-                    fn[fn.length - 1] += '__fest_blocks' + getName(_getAttr(node, 'name')) + '=function(' + context_name + ',params){';
-                    fn[fn.length - 1] += 'if (typeof document === "undefined"){var document = {write:function(string){__fest_pushstr(' + context_name + ',string);}};}';
-                    fn[fn.length - 1] += 'var __fest_result=[],__fest_str="",__fest_pushstr;';
-                    fn[fn.length - 1] += '__fest_pushstr=function(ctx,str){__fest_str+=str};';
+                    section.source += 'if(__fest_if){';
+                    section.source += '__fest_blocks' + getName(_getAttr(node, 'name')) + '=function(' + context_name + ',params){';
+                    section.source += 'if (typeof document === "undefined"){var document = {write:function(string){__fest_pushstr(' + context_name + ',string);}};}';
+                    section.source += 'var __fest_result=[],__fest_str="",__fest_pushstr;';
+                    section.source += '__fest_pushstr=function(ctx,str){__fest_str+=str};';
                     return;
                 case 'get':
-                    fn[fn.length - 1] += '__fest_result[__fest_result.length]=__fest_str;';
-                    fn[fn.length - 1] += '__fest_str="";';
+                    section.source += '__fest_result[__fest_result.length]=__fest_str;';
+                    section.source += '__fest_str="";';
                     if (node.attributes.select){
-                        fn[fn.length - 1] += 'try{__fest_select=' + _getAttr(node, 'select', 'expr') + '}catch(e){__fest_select==="__error__";__fest_log_error(e.message)}';
+                        section.source += 'try{__fest_select=' + _getAttr(node, 'select', 'expr') + '}catch(e){__fest_select==="__error__";__fest_log_error(e.message)}';
+                        output.disable_sgo = true;
                     } else {
-                        fn[fn.length - 1] += '__fest_select="' + escapeJS(_getAttr(node, 'name')) + '";';
+                        section.source += '__fest_select="' + escapeJS(_getAttr(node, 'name')) + '";';
+                        output.uses.push(_getAttr(node, 'name'));
                     }
-                    fn[fn.length - 1] += '__fest_result[__fest_result.length]=function(' + context_name + ',params, __fest_select){';
-                    fn[fn.length - 1] += 'return function(){';
-                    fn[fn.length - 1] += 'return (__fest_select in __fest_blocks) ? __fest_blocks[__fest_select].call(__fest_self,' + context_name + ', params) : [];';
-                    fn[fn.length - 1] += '};';
-                    fn[fn.length - 1] += '};';
-                    fn[fn.length - 1] += 'try{__fest_params=false';
+                    section.source += '__fest_result[__fest_result.length]=function(' + context_name + ',params, __fest_select){';
+                    section.source += 'return function(){';
+                    section.source += 'return (__fest_select in __fest_blocks) ? __fest_blocks[__fest_select].call(__fest_self,' + context_name + ', params) : [];';
+                    section.source += '};';
+                    section.source += '};';
+                    section.source += 'try{__fest_params=false';
                     return;
                 case 'include':
                     if (node.attributes.context){
-                        fn[fn.length - 1] += '__fest_contexts[__fest_contexts.length] = ' + context_name + ';';
-                        fn[fn.length - 1] += 'try{' + context_name + '=' + _getAttr(node, 'context', 'expr') + '}catch(e){' + context_name + '={};__fest_log_error(e.message)};';
+                        section.source += '__fest_contexts[__fest_contexts.length] = ' + context_name + ';';
+                        section.source += 'try{' + context_name + '=' + _getAttr(node, 'context', 'expr') + '}catch(e){' + context_name + '={};__fest_log_error(e.message)};';
                     }
-                    _compile(dirname(file) + '/' + _getAttr(node, 'src'), context_name, callbacks, options,
-                        function(fn, index){return function(template){
-                            fn[index] += template;
-                        };}(fn, fn.length - 1));
+                    _compile(dirname(file) + '/' + _getAttr(node, 'src'), context_name, callbacks, options, output);
+                    section = flush(section.parent);
                     if (node.attributes.context){
-                        fn[fn.length] = context_name + '=__fest_contexts.pop();';
-                    } else {
-                        fn[fn.length] = '';
+                        section.source += context_name + '=__fest_contexts.pop();';
                     }
                     return;
             }
@@ -421,79 +425,80 @@ var compile = (function(){
         parser.onclosetag = function () {
             var node = this.tag;
 
-            if (callback('closetag', node, fn, callbacks) !== false) return;
+            if (callback('closetag', node, section, callbacks) !== false) return;
 
-            opentag = closetag(stack, node.local, fn, opentag, context_name);
+            opentag = closetag(stack, node.local, section, opentag, context_name);
 
             stack.pop();
 
             if (node.ns[node.prefix] != fest_ns){
                 if (!(node.name in short_tags)){
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"</' + node.name + '>");';
+                    section.source += '__fest_pushstr(' + context_name + ',"</' + node.name + '>");';
                 }
                 return;
             }
             switch (node.local){
                 case 'element':
-                    fn[fn.length - 1] += '__fest_elementName = __fest_element_stack[__fest_element_stack.length - 1];';
-                    fn[fn.length - 1] += 'if(!(__fest_elementName in __fest_short_tags)){__fest_pushstr(' + context_name + ',"</" + __fest_elementName + ">")}';
-                    fn[fn.length - 1] += '__fest_element_stack.pop();';
+                    section.source += '__fest_elementName = __fest_element_stack[__fest_element_stack.length - 1];';
+                    section.source += 'if(!(__fest_elementName in __fest_short_tags)){__fest_pushstr(' + context_name + ',"</" + __fest_elementName + ">")}';
+                    section.source += '__fest_element_stack.pop();';
                     return;
                 case 'doctype':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',">");';
+                    section.source += '__fest_pushstr(' + context_name + ',">");';
                     return;
                 case 'comment':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"-->");';
+                    section.source += '__fest_pushstr(' + context_name + ',"-->");';
                     return;
                 case 'attribute':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"\\"");';
+                    section.source += '__fest_pushstr(' + context_name + ',"\\"");';
                     return;
                 case 'cdata':
-                    fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"]]>");';
+                    section.source += '__fest_pushstr(' + context_name + ',"]]>");';
                     return;
                 case 'if':
-                    fn[fn.length - 1] += '}';
+                    section.source += '}';
                     return;
                 case 'otherwise':
                     return;
                 case 'foreach':
                 case 'each':
                 case 'for':
-                    fn[fn.length - 1] += '}';
+                    section.source += '}';
                     return;
                 case 'choose':
                     (function(length){
                         for (var i = 0; i < length; i++){
-                            fn[fn.length - 1] += '}';
+                            section.source += '}';
                         }
                     })(choose.pop());
                     return;
                 case 'when':
-                    fn[fn.length - 1] += '}else{';
+                    section.source += '}else{';
                     return;
                 case 'value':
-                    fn[fn.length - 1] += ')';
+                    section.source += ')';
                     if (node.__fest_output !== 'text'){
-                        fn[fn.length - 1] += ')';
+                        section.source += ')';
                     }
                     if (!node.attributes.safe){
-                        fn[fn.length - 1] += ';}catch(e){__fest_log_error(e.message + "' + this.line + '");}';
+                        section.source += ';}catch(e){__fest_log_error(e.message + "' + this.line + '");}';
                     } else {
-                        fn[fn.length - 1] += ';';
+                        section.source += ';';
                     }
                     return;
                 case 'set':
-                    fn[fn.length - 1] += '__fest_result[__fest_result.length]=__fest_str;';
-                    fn[fn.length - 1] += 'return __fest_result;';
-                    fn[fn.length - 1] += '};}';
+                    section.source += '__fest_result[__fest_result.length]=__fest_str;';
+                    section.source += 'return __fest_result;';
+                    section.source += '};}';
+                    section = flush(section.parent.parent, section.parent.name);
                     return;
                 case 'get':
-                    fn[fn.length - 1] += ';}catch(e){__fest_params={};__fest_log_error(e.message);}';
-                    fn[fn.length - 1] += '__fest_result[__fest_result.length - 1]=__fest_result[__fest_result.length - 1](' + context_name + ',__fest_params, __fest_select);';
+                    section.source += ';}catch(e){__fest_params={};__fest_log_error(e.message);}';
+                    section.source += '__fest_result[__fest_result.length - 1]=__fest_result[__fest_result.length - 1](' + context_name + ',__fest_params, __fest_select);';
                     return;
                 case 'script':
                     if (!node.attributes.safe){
-                        fn[fn.length - 1] += '}catch(e){__fest_log_error(e.message);}';
+                        section.source += '}catch(e){__fest_log_error(e.message);}';
                     }
                     return;
                 case 'template':
@@ -504,44 +509,43 @@ var compile = (function(){
         };
         var evallist = ['value', 'script', 'get'];
         parser.ontext = function (text) {
-            //console.log(this.line);
-            if (callback('text', text, fn, callbacks) !== false) return;
-            opentag = closetag(stack, 'text', fn, opentag, context_name);
+            if (callback('text', text, section, callbacks) !== false) return;
+            opentag = closetag(stack, 'text', section, opentag, context_name);
             if (evallist.indexOf(stack[stack.length - 1]) === -1){
-                fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"' + escapeJS(text) + '");';
+                section.source += '__fest_pushstr(' + context_name + ',"' + escapeJS(text) + '");';
             } else if (stack[stack.length - 1] === 'get') {
-                fn[fn.length - 1] += ' || ' + _getExpr(text);
+                section.source += ' || ' + _getExpr(text);
             } else if (stack[stack.length - 1] === 'value') {
-                fn[fn.length - 1] += _getExpr(text);
+                section.source += _getExpr(text);
             } else {
-                fn[fn.length - 1] += _getEval(text);
+                section.source += _getEval(text);
             }
         };
         parser.oncdata = function (cdata) {
-            if (callback('cdata', cdata, fn, callbacks) !== false) return;
-            opentag = closetag(stack, 'cdata', fn, opentag, context_name);
+            if (callback('cdata', cdata, section, callbacks) !== false) return;
+            opentag = closetag(stack, 'cdata', section, opentag, context_name);
             if (evallist.indexOf(stack[stack.length - 1]) === -1){
-                fn[fn.length - 1] += '__fest_pushstr(' + context_name + ',"' + escapeJS(cdata) + '");';
+                section.source += '__fest_pushstr(' + context_name + ',"' + escapeJS(cdata) + '");';
             } else if (stack[stack.length - 1] === 'get') {
-                fn[fn.length - 1] += ' || ' + _getExpr(cdata);
+                section.source += ' || ' + _getExpr(cdata);
             } else if (stack[stack.length - 1] === 'value') {
-                fn[fn.length - 1] += _getExpr(cdata);
+                section.source += _getExpr(cdata);
             } else {
-                fn[fn.length - 1] += _getEval(cdata);
+                section.source += _getEval(cdata);
             }
         };
         parser.onend = function () {
             if (compile_file && !templateClosed) {
                 throw new Error(file + "\n" + errorMessage('fest:template is not closed', parser.line, compile_file));
             }
-
-            cb(fn.join('').replace(/"\);__fest_pushstr\([^,]*,"/g, ''));
         };
 
         if (compile_file){
             parser.write(compile_file);
         }
         parser.close();
+
+        return output;
     }
 
     function finish_compile(file, options, name){
@@ -552,7 +556,26 @@ var compile = (function(){
         options.sax = options.sax || {trim:true, xmlns:true};
         options.sax.strict = options.sax.strict || true;
 
-        function build_template(result) {
+        function build_template(output) {
+
+            function is_used(section) {
+                while (section) {
+                    if (section.name && output.uses.indexOf(section.name) == -1) {
+                        return false;
+                    }
+                    section = section.parent;
+                }
+                return true;
+            }
+
+            var source = '';
+            output.sections.forEach(function (section) {
+                if (output.disable_sgo || is_used(section)) {
+                    source += section.source;
+                }
+            });
+            source = source.replace(/"\);__fest_pushstr\([^,]*,"/g, '');
+
             template  = 'function ' + name + '(__fest_context){"use strict";' +
                         'var __fest_self=this,__fest_str="",__fest_result=[],__fest_contexts=[],__fest_attrs=[],__fest_select,__fest_if,__fest_foreach,__fest_from,__fest_to,__fest_html = "",' +
                         '__fest_blocks={},__fest_params,__fest_log_error,___fest_log_error,__fest_elementName,__fest_pushstr,' +
@@ -577,7 +600,7 @@ var compile = (function(){
                         'return s.replace(__fest_htmlchars,__fest_replaceHTML);}' +
                         'if (typeof document === "undefined"){var document = {write:function(string){__fest_pushstr(__fest_context, string);}};}' +
                         'function __fest_log_error(message){___fest_log_error(message+"\\nin block \\""+__fest_debug_block+"\\" at line: "+__fest_debug_line+"\\nfile: "+__fest_debug_file)}';
-            template += result;
+            template += source;
             template += '__fest_result[__fest_result.length]=__fest_str;' +
                         'if(__fest_result.length === 1){return __fest_result[0]}' +
                         'function setblocks(list){' +
@@ -591,7 +614,7 @@ var compile = (function(){
         }
 
         try {
-            _compile(file, '__fest_context', callbacks, options, build_template);
+            build_template(_compile(file, '__fest_context', callbacks, options));
             if (options.beautify) template = js_beautify(template);
         } catch (e) {
             if (!options.nothrow) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -224,7 +224,7 @@ var compile = (function(){
     }
 
     function _compile (file, context_name, callbacks, options, output){
-        output = output || {sections: [], uses: []};
+        output = output || {sections: [], uses: {}};
 
         var counters = {counter: 0, promises: 1},
             choose = [],
@@ -239,11 +239,10 @@ var compile = (function(){
             _getEval = getEval(compile_file, parser),
             attrs;
 
-        function flush(parent, name) {
+        function flush(name) {
             var section = {
                 source: '',
-                name: name,
-                parent: parent
+                name: name
             };
             output.sections.push(section);
             return section;
@@ -262,6 +261,10 @@ var compile = (function(){
 
             if (node.local == 'attributes' && stack[stack.length - 1] == 'attributes') {
                 throw new Error(file + "\n" + errorMessage('fest:attributes cannot be nested', parser.line, compile_file));
+            }
+
+            if (node.local == 'set' && stack.indexOf('set') !== -1) {
+                throw new Error(file + "\n" + errorMessage('fest:set cannot be nested', parser.line, compile_file));
             }
 
             if (node.ns[node.prefix] != fest_ns){
@@ -379,7 +382,7 @@ var compile = (function(){
                     counters.counter++;
                     return;
                 case 'set':
-                    section = flush(section, _getAttr(node, 'name'));
+                    section = flush(_getAttr(node, 'name'));
                     if (node.attributes.test){
                         section.source += 'try{__fest_if=' + _getAttr(node, 'test', 'expr') + '}catch(e){__fest_if=false; __fest_log_error(e.message)}';
                     } else {
@@ -399,7 +402,7 @@ var compile = (function(){
                         output.disable_sgo = true;
                     } else {
                         section.source += '__fest_select="' + escapeJS(_getAttr(node, 'name')) + '";';
-                        output.uses.push(_getAttr(node, 'name'));
+                        output.uses[_getAttr(node, 'name')] = true;
                     }
                     section.source += '__fest_result[__fest_result.length]=function(' + context_name + ',params, __fest_select){';
                     section.source += 'return function(){';
@@ -414,7 +417,7 @@ var compile = (function(){
                         section.source += 'try{' + context_name + '=' + _getAttr(node, 'context', 'expr') + '}catch(e){' + context_name + '={};__fest_log_error(e.message)};';
                     }
                     _compile(dirname(file) + '/' + _getAttr(node, 'src'), context_name, callbacks, options, output);
-                    section = flush(section.parent);
+                    section = flush();
                     if (node.attributes.context){
                         section.source += context_name + '=__fest_contexts.pop();';
                     }
@@ -490,7 +493,7 @@ var compile = (function(){
                     section.source += '__fest_result[__fest_result.length]=__fest_str;';
                     section.source += 'return __fest_result;';
                     section.source += '};}';
-                    section = flush(section.parent.parent, section.parent.name);
+                    section = flush();
                     return;
                 case 'get':
                     section.source += ';}catch(e){__fest_params={};__fest_log_error(e.message);}';
@@ -558,19 +561,9 @@ var compile = (function(){
 
         function build_template(output) {
 
-            function is_used(section) {
-                while (section) {
-                    if (section.name && output.uses.indexOf(section.name) == -1) {
-                        return false;
-                    }
-                    section = section.parent;
-                }
-                return true;
-            }
-
             var source = '';
             output.sections.forEach(function (section) {
-                if (output.disable_sgo || is_used(section)) {
+                if (output.disable_sgo || section.name === undefined || output.uses[section.name]) {
                     source += section.source;
                 }
             });

--- a/tests/templates/set_nested.xml
+++ b/tests/templates/set_nested.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
-    <fest:set name="qux" test="false">
-        qux
+    <fest:set name="foo">
+        foo
+        <fest:set name="bar">
+            bar
+        </fest:set>
     </fest:set>
 </fest:template>

--- a/tests/templates/useless_set.xml
+++ b/tests/templates/useless_set.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0"?>
 <fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
-    foo
-    <fest:set name="bar" test="true">
-        bar
-        <fest:set name="bax"> <!-- useless because "bar" is useless -->
-            bax
-        </fest:set>
+    <fest:get name="foo" />
+    <fest:set name="foo">
+        foo
     </fest:set>
-    <fest:include src="unused_set_include.xml" /> <!-- contains useless another one "bax" -->
+    <fest:set name="bar">
+        bar
+    </fest:set>
     <fest:set name="baz" test="true">
         baz
     </fest:set>
-    <fest:get name="baz" />
-    <fest:get name="bax" /> <!-- will be undefined -->
+    <fest:include src="useless_set_include.xml" />
 </fest:template>

--- a/tests/templates/useless_set.xml
+++ b/tests/templates/useless_set.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
+    foo
+    <fest:set name="bar" test="true">
+        bar
+        <fest:set name="bax"> <!-- useless because "bar" is useless -->
+            bax
+        </fest:set>
+    </fest:set>
+    <fest:include src="unused_set_include.xml" /> <!-- contains useless another one "bax" -->
+    <fest:set name="baz" test="true">
+        baz
+    </fest:set>
+    <fest:get name="baz" />
+    <fest:get name="bax" /> <!-- will be undefined -->
+</fest:template>

--- a/tests/templates/useless_set_include.xml
+++ b/tests/templates/useless_set_include.xml
@@ -2,7 +2,7 @@
 <fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
     <fest:set name="quz">
         quz
-        <fest:set name="bax"> <!-- useless because "bar" is useless -->
+        <fest:set name="bax"> <!-- useless because "quz" is useless -->
             bax
         </fest:set>
     </fest:set>

--- a/tests/templates/useless_set_include.xml
+++ b/tests/templates/useless_set_include.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
+    <fest:set name="quz">
+        quz
+        <fest:set name="bax"> <!-- useless because "bar" is useless -->
+            bax
+        </fest:set>
+    </fest:set>
+</fest:template>

--- a/tests/templates/useless_set_select.xml
+++ b/tests/templates/useless_set_select.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
+    foo
+    <fest:set name="bar" test="true">
+        bar
+        <fest:set name="bax">
+            bax
+        </fest:set>
+    </fest:set>
+    <fest:include src="unused_set_include.xml" />
+    <fest:set name="baz" test="true">
+        baz
+    </fest:set>
+    <fest:get name="baz" />
+    <fest:get select="json" />
+</fest:template>

--- a/tests/templates/useless_set_select.xml
+++ b/tests/templates/useless_set_select.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0"?>
 <fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
-    foo
-    <fest:set name="bar" test="true">
-        bar
-        <fest:set name="bax">
-            bax
-        </fest:set>
+    <fest:get select="json" />
+    <fest:set name="foo">
+        foo
     </fest:set>
-    <fest:include src="unused_set_include.xml" />
+    <fest:set name="bar">
+        bar
+    </fest:set>
     <fest:set name="baz" test="true">
         baz
     </fest:set>
-    <fest:get name="baz" />
-    <fest:get select="json" />
+    <fest:include src="useless_set_include.xml" />
 </fest:template>

--- a/tests/tests-fest.js
+++ b/tests/tests-fest.js
@@ -506,5 +506,5 @@ vows.describe('Fast tests').addBatch({
             assert.isTrue(result.indexOf('__fest_blocks.baz') > -1);
             assert.isTrue(result.indexOf('__fest_blocks.bax') > -1);
         }
-    },
+    }
 }).run();

--- a/tests/tests-fest.js
+++ b/tests/tests-fest.js
@@ -8,6 +8,7 @@ function transform(file, json, thisArg, promise, strict, options){
     var template = fest.compile(__dirname + file, options);
     template = (new Function('return ' + template))();
     setTimeout(function(){promise.emit('success', template.call(thisArg, json));}, 0);
+    return template;
 }
 
 vows.describe('Fast tests').addBatch({
@@ -299,7 +300,6 @@ vows.describe('Fast tests').addBatch({
             return promise;
         },
         'result':function(result){
-            console.log(result);
             result = result.split('|');
             assert.equal(result.length, 12);
             assert.equal(result[1], 'one');
@@ -486,5 +486,25 @@ vows.describe('Fast tests').addBatch({
         'result':function(result) {
           assert.equal(result, '');
         }
-    }
+    },
+    'useless set blocks': {
+        topic:function(){
+            return fest.compile(__dirname + '/templates/useless_set.xml');
+        },
+        'result':function(result){
+            assert.isTrue(result.indexOf('__fest_blocks.bar') == -1);
+            assert.isTrue(result.indexOf('__fest_blocks.baz') > -1);
+            assert.isTrue(result.indexOf('__fest_blocks.bax') == -1);
+        }
+    },
+    'useless set blocks when get block with select is defined': {
+        topic:function(){
+            return fest.compile(__dirname + '/templates/useless_set_select.xml');
+        },
+        'result':function(result){
+            assert.isTrue(result.indexOf('__fest_blocks.bar') > -1);
+            assert.isTrue(result.indexOf('__fest_blocks.baz') > -1);
+            assert.isTrue(result.indexOf('__fest_blocks.bax') > -1);
+        }
+    },
 }).run();

--- a/tests/tests-fest.js
+++ b/tests/tests-fest.js
@@ -8,7 +8,6 @@ function transform(file, json, thisArg, promise, strict, options){
     var template = fest.compile(__dirname + file, options);
     template = (new Function('return ' + template))();
     setTimeout(function(){promise.emit('success', template.call(thisArg, json));}, 0);
-    return template;
 }
 
 vows.describe('Fast tests').addBatch({
@@ -487,14 +486,25 @@ vows.describe('Fast tests').addBatch({
           assert.equal(result, '');
         }
     },
+    'nested set blocks': {
+        topic:function(){
+            var promise = new(events.EventEmitter);
+            transform('/templates/set_nested.xml', {}, {}, promise, true, {nothrow: true});
+            return promise;
+        },
+        'result':function(result){
+            assert.include(result, 'At line 5: fest:set cannot be nested');
+        }
+    },
     'useless set blocks': {
         topic:function(){
             return fest.compile(__dirname + '/templates/useless_set.xml');
         },
         'result':function(result){
+            assert.isTrue(result.indexOf('__fest_blocks.foo') > -1);
             assert.isTrue(result.indexOf('__fest_blocks.bar') == -1);
-            assert.isTrue(result.indexOf('__fest_blocks.baz') > -1);
-            assert.isTrue(result.indexOf('__fest_blocks.bax') == -1);
+            assert.isTrue(result.indexOf('__fest_blocks.baz') == -1);
+            assert.isTrue(result.indexOf('__fest_blocks.qux') == -1);
         }
     },
     'useless set blocks when get block with select is defined': {
@@ -502,9 +512,10 @@ vows.describe('Fast tests').addBatch({
             return fest.compile(__dirname + '/templates/useless_set_select.xml');
         },
         'result':function(result){
+            assert.isTrue(result.indexOf('__fest_blocks.foo') > -1);
             assert.isTrue(result.indexOf('__fest_blocks.bar') > -1);
             assert.isTrue(result.indexOf('__fest_blocks.baz') > -1);
-            assert.isTrue(result.indexOf('__fest_blocks.bax') > -1);
+            assert.isTrue(result.indexOf('__fest_blocks.qux') > -1);
         }
     }
 }).run();


### PR DESCRIPTION
В выходном шаблоне должны присутствовать только использующиеся  `set` блоки. В случае если хотя бы один `get` блок был объявлен с `select`, тогда оптимизация не будет выполнена.

Пример:

``` xml
<?xml version="1.0"?>
<fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
    <fest:get name="foo" />
    <fest:set name="foo">
        foo
    </fest:set>
    <fest:set name="bar">
        bar
    </fest:set>
</fest:template>
```

В данном случае, в коде шаблона будет присутствовать блок `set` с именем `bar`. Теперь представим шаблон utils.xml, который напичкан сотней set блоков, и это файл включается в каждый шаблон, отправляемый клиенту. Клиент, получает огромное количество ненужного никому кода.

Для решения данной проблемы было сделано следующее. Код генерируется секционно. Блок `set` закрывает текущую безымянную секцию и открывает новую именованную (по значению атрибута `name`). По выходу из именованной секции создается новая безымянная. При сборке шаблона остаются только безымянные секции и именные секции, которые были упомянуты в блоках `get`.
