### PR TITLE
Более лучшая интеграция с NPM

### DIFF
--- a/bin/fest-proxy
+++ b/bin/fest-proxy
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/proxy');

--- a/bin/fest-watch
+++ b/bin/fest-watch
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/watch');

--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+    * fest-watch and fest-proxy commands
 	* not recursive and named templates added to watch
 v 0.3.1
 	* fix js escape inside html script tag

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -1,10 +1,12 @@
-module.exports = function(){
-    var args = process.argv.slice(2)
-                           .map(function(arg){return arg.split('=')});
-
-    var result = {};
-    args.forEach(function(arg){
-        result[arg[0].trim().replace(/^--/, '')] = typeof arg[1] === 'undefined' ? true : arg[1].trim();
+module.exports = function() {
+    var result = [];
+    process.argv.slice(2).forEach(function (arg) {
+        if (0 === arg.indexOf('--')) {
+            var kv = arg.slice(2).split(/\s*=\s*/);
+            result[kv[0]] = typeof kv[1] === 'undefined' ? true : kv[1];
+        } else {
+            result.push(arg);
+        }
     })
     return result;
 }()

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -11,20 +11,42 @@ var
 	, fs        = require('fs')
 	, URL       = require('url')
 	, http      = require('http')
-	, argv      = process.argv
+    , cmd       = require('./cmd');
 ;
 
+function help() {
+    console.log([
+        'Usage:',
+        '  fest-proxy [options] [config]',
+        '',
+        'Options:',
+        '  --version current frontier version',
+        '  --help    display these usage instructions',
+        ''
+    ].join('\n'));
+    process.exit(0);
+}
+
+function version() {
+    console.log(JSON.parse(fs.readFileSync(__dirname + '/../package.json')).version);
+    process.exit(0);
+}
+
+if (cmd.help || cmd.length > 1) {
+    help();
+} else if (cmd.version) {
+    version();
+}
 
 // Get config
-if( argv[2] ){
-	fs.readFile(argv[2], function (err, config) {
+if (cmd[0]) {
+	fs.readFile(cmd[0], function (err, config) {
 		if( err ){ throw err; }
 		new Proxy(JSON.parse(config));
 	});
 } else {
 	new Proxy();
 }
-
 
 function Proxy(config){
 	// default

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -4,17 +4,39 @@ var fs = require('fs'),
     cmd = require('./cmd');
 var existsSync = fs.existsSync || path.existsSync;
 
-var prefix = '';
+function help() {
+    console.log([
+        'Usage:',
+        '  fest-watch --dir=... [--out=...]',
+        '',
+        'Options:',
+        '  --dir     directory where .xml files are',
+        '  --out     out directory for compiled files if omited --out = --dir',
+        '  --version current frontier version',
+        '  --help    display these usage instructions',
+        ''
+    ].join('\n'));
+    process.exit(0);
+}
 
+function version() {
+    console.log(JSON.parse(fs.readFileSync(__dirname + '/../package.json')).version);
+    process.exit(0);
+}
+
+if (cmd.help) {
+    help();
+} else if (cmd.version) {
+    version();
+}
+
+var prefix = '';
 var recursive = cmd.recursive !== 'no';
 var dir = cmd.dir;
-if (cmd.help) {
-    console.log('node watch.js --dir=... [--out=...]\n--dir directory where .xml files are\n--out out directory for compiled files if omited --out = --dir');
-    return;
-}
+
 if (!dir){
-    console.log('You need to pint directory "node watch.js dir=..."');
-    return;
+    console.log('You need to print directory "fest-watch dir=..."');
+    process.exit(1);
 }
 if (dir[0] !== '/'){
     dir = process.env.PWD + '/' + dir;
@@ -22,7 +44,7 @@ if (dir[0] !== '/'){
 dir = dir.replace(/\/$/, '') + '/';
 if (!existsSync(dir)){
     console.log('directory "' + dir + '" does not exists');
-    return;
+    process.exit(1);
 }
 var out_dir = cmd.out || dir;
 out_dir = out_dir.replace(/\/$/, '') + '/';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fest",
-    "description": "JS Templates",
+    "description": "JavaScript Templates",
     "keywords": ["template", "templating", "html", "xml"],
     "version": "0.3.1",
     "repository": {
@@ -9,15 +9,24 @@
     },
     "author": "Andrew Sumin <AndrewSumin@mail.ru>",
     "contributors": [
-        "Anton Eprev <a.eprev@gmail.com> (http://eprev.me)",
+        "Anton Eprev <a.eprev@gmail.com>",
         "Lebedev Konstantin <ibnrubaxa@gmail.com>",
         "Max Maximov <max.maximov@gmail.com> (http://maxmaximov.com)",
         "Artem Tyurin"
     ],
     "main": "./lib/fest",
+    "bin": {
+        "fest-proxy": "./bin/fest-proxy",
+        "fest-watch": "./bin/fest-watch"
+    },
     "engines": {
         "node": "*"
     },
+    "scripts": {
+        "test": "node tests/tests.js"
+    },
     "dependencies": {},
-    "devDependencies": {}
+    "devDependencies": {
+        "vows": "*"
+    }
 }


### PR DESCRIPTION
После `npm install -g fest` в системе доступны команды `fest-watch` и `fest-proxy`.

Переписал модуль `cmd`, чтобы он умел работать не только с аргументами --key=value, но и простыми аргументами, которые бы собирались в массив. На выходе имеем индексный массив, у которого есть так же строковые ключи. Например, для `node cmd.js arg1 --key1=value1 arg2 --key2=value2` получаем:

``` Javascript
cmd.length == 2
cmd[0] == 'arg1'
cmd[1] == 'arg2'
cmd['key1'] == 'value1'
cmd['key2'] == 'value2'
```

`fest-proxy` использует теперь модуль `cmd`.

Добавил `vows` в dev dependencies. Теперь он установится при npm install --dev в каталоге с исходниками феста.

Тесты можно запускать теперь с помощью `npm test`. Предлагаю [travis](http://travis-ci.org) подключить.
