### PR TITLE
wrap include in a closure

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+    * wrapping fest:include in a closure
     * improved the performance of escape functions
     * copy watch.js to build.js, watch.js will be demonized in future
     * render() in fest API

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -415,15 +415,16 @@ var compile = (function(){
                     section.source += 'try{__fest_params=false';
                     return;
                 case 'include':
+                    var inner_context_name = context_name;
                     if (node.attributes.context){
-                        section.source += '__fest_contexts[__fest_contexts.length] = ' + context_name + ';';
-                        section.source += 'try{' + context_name + '=' + _getAttr(node, 'context', 'expr') + '}catch(e){' + context_name + '={};__fest_log_error(e.message)};';
+                        inner_context_name = '__fest_context' + counters.counter;
+                        section.source += 'var ' + inner_context_name + ';try{' + inner_context_name + '=' + _getAttr(node, 'context', 'expr') + '}catch(e){' + inner_context_name + '={};__fest_log_error(e.message)};';
+                        counters.counter++;
                     }
-                    _compile(dirname(file) + '/' + _getAttr(node, 'src'), context_name, callbacks, options, output);
+                    section.source += '(function(__fest_context){'
+                    _compile(dirname(file) + '/' + _getAttr(node, 'src'), '__fest_context', callbacks, options, output);
                     section = flush();
-                    if (node.attributes.context){
-                        section.source += context_name + '=__fest_contexts.pop();';
-                    }
+                    section.source += '})(' + inner_context_name +');';
                     return;
             }
         };

--- a/tests/templates/include.xml
+++ b/tests/templates/include.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
-    <fest:include context="json.list" src="./include_foreach.xml"/>
+    <fest:foreach iterate="json.list" index="i" value="item">
+        <fest:include context="item" src="./include_foreach.xml"/>
+    </fest:foreach>
     <fest:include context="json.list" src="./nofile.xml"/>
 </fest:template>

--- a/tests/templates/include_foreach.xml
+++ b/tests/templates/include_foreach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <fest:template xmlns:fest="http://fest.mail.ru" context_name="list">
-    <fest:foreach iterate="list" index="i">
-        <fest:value>list[i]</fest:value>
+    <fest:foreach iterate="list" index="i" value="item">
+        <fest:value>item</fest:value>
     </fest:foreach>
 </fest:template>

--- a/tests/templates/setparams.xml
+++ b/tests/templates/setparams.xml
@@ -6,9 +6,13 @@
     <fest:get name="one">{text:'text2'}</fest:get>
     <fest:set name="one">|<fest:script>params.text2 = params.text;</fest:script><fest:value>params.text2</fest:value>|</fest:set>
 
-	<fest:get name="one">'' || {text:'text3'}</fest:get>
+    <fest:get name="one">'' || {text:'text3'}</fest:get>
     <fest:set name="one">|<fest:value>params.text</fest:value>|</fest:set>
 
-	<fest:get name="one">{text:'text4'}</fest:get>
+    <fest:get name="one">{text:'text4'}</fest:get>
     <fest:set name="one">|<fest:value>params.text</fest:value>|</fest:set>
+
+    <fest:set name="two">|<fest:value>params.text</fest:value>main|</fest:set>
+    <fest:get name="two">{text:'set in '}</fest:get>
+    <fest:include src="setparams_inner.xml" context="{}" />
 </fest:template>

--- a/tests/templates/setparams_inner.xml
+++ b/tests/templates/setparams_inner.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<fest:template xmlns:fest="http://fest.mail.ru" context_name="json">
+    <fest:set name="two">|<fest:value>params.text</fest:value>inner|</fest:set>
+</fest:template>

--- a/tests/tests-include.js
+++ b/tests/tests-include.js
@@ -7,11 +7,11 @@ vows.describe('Fest tests').addBatch({
     'include':{
         topic:function(){
             var promise = new(events.EventEmitter);
-            transform('/templates/include.xml', {list:[1, 2]}, {}, promise);
+            transform('/templates/include.xml', {list:[[1, 2, 3], [4, 5, 6]]}, {}, promise);
             return promise;
         },
         'result':function(result){
-            assert.equal(result, '12');
+            assert.equal(result, '123456');
         }
     },
     'include with syntax errors in context attribute':{

--- a/tests/tests-set.js
+++ b/tests/tests-set.js
@@ -22,7 +22,7 @@ vows.describe('Fest tests').addBatch({
             return promise;
         },
         'result':function(result){
-            assert.equal(result, '|text1||text2||text3||text4|');
+            assert.equal(result, '|text1||text2||text3||text4||set in inner|');
         }
     },
     'nested set blocks': {

--- a/tests/transform.js
+++ b/tests/transform.js
@@ -4,7 +4,7 @@ module.exports = function(file, json, thisArg, promise, strict, options, lang, c
     options = options || {};
     options.beautify = true;
     var template = fest.compile(__dirname + file, options, lang, callbacks);
-    //console.log(template);
+    // console.log(template);
     template = (new Function('return ' + template))();
     setTimeout(function(){promise.emit('success', template.call(thisArg, json));}, 0);
 }


### PR DESCRIPTION
Шаблон, который подключается в другой шаблон, не должен загрязнять контекст вызывающего шаблона. Помимо загрязнения возможны конфликты имен переменных. Например, при include в цикле, когда в подключаемом шаблоне есть имена переменных или циклы с именами, которые используются в родительском. Единственный способ влиять на родительский шаблон, это fest:set.

Сделал тесты соответствующие. 

Шаблоны, которые подключаются через fest:include заворачиваются в анонимные функции и вызываются.
