### PR TITLE
windows paths support in compile.js

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -31,7 +31,9 @@ var compile = (function(){
 		return result;
 	};
 	dirname = function(path){
-		return path.substring(0, path.lastIndexOf('/'));
+		var idx = path.lastIndexOf('/');
+		if (idx == -1) idx = path.lastIndexOf('\\');
+		return idx != 1 ? path.substring(0, idx) : path;
 	};
 
 	var sax = (new Function(readFileSync(__dirname + '/sax.js').toString() + ' return sax;'))();


### PR DESCRIPTION
By default only linux paths processed correctly by dirname function in compile.js.
Windows paths with backslashes are not processed correctly, so fest:include can not find *.xml files on Windows.
