### PR TITLE
Add debug callback

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -242,9 +242,17 @@ var compile = (function(){
 		if (!debug){
 			return;
 		}
-		section.source += '__fest_debug_file="' + escapeJS(compile_file) + '";';
-		section.source += '__fest_debug_line="' + parser.line + '";';
-		section.source += '__fest_debug_block="' + block + '";';
+		var debug_info = {
+			file: compile_file,
+			line: parser.line,
+			block: block
+		};
+		if (typeof debug === 'function') {
+			debug_info = debug(debug_info);
+		}
+		section.source += '__fest_debug_file="' + escapeJS(debug_info.file) + '";';
+		section.source += '__fest_debug_line="' + debug_info.line + '";';
+		section.source += '__fest_debug_block="' + debug_info.block + '";';
 	}
 
 	function _compile (data){


### PR DESCRIPTION
Колбэк, передаваемый в опции debug и позволяющий при сборке обрабатывать/модифицировать отладочную информацию.
Например – резать абсолютные пути к исходникам:

``` javascript
function (debugInfo) {
    debugInfo.file = debugInfo.file.split('/').slice(-3).join('/');
    return debugInfo;
}
```
